### PR TITLE
Import curl landing Cloudflare worker

### DIFF
--- a/infrastructure/cloudflare-workers/curl-landing/Pulumi.global.yaml
+++ b/infrastructure/cloudflare-workers/curl-landing/Pulumi.global.yaml
@@ -1,2 +1,5 @@
 secretsprovider: gcpkms://projects/fabien-sh-pulumi/locations/global/keyRings/pulumi/cryptoKeys/secrets
 encryptedkey: CiQABF63TiPMtReBKxGQ8HjpXrtLUi/IIQu81E3NwBHb0EfBQkgSSQAaDax6pOG5sEiVrSWY8TsA7FdMVu9EU8te+E+LM+E+C+I+oEYxYEMeTn+1Ock+ql9Db5gD8FuN/G8sz9LJU83Nh/2i0ls/dU4=
+config:
+  cloudflare:apiToken:
+    secure: v1:BMwYeji3XTp7AzO6:vwuISR/KgoD/wkP3keQeuZvywUFCRqhLnk3x6lnpLZgD5BVv0SVaaGE1IZ4cHYrj/OsG6ireOSU=

--- a/infrastructure/cloudflare-workers/curl-landing/index.ts
+++ b/infrastructure/cloudflare-workers/curl-landing/index.ts
@@ -1,1 +1,54 @@
-import * as pulumi from "@pulumi/pulumi";
+import * as cloudflare from "@pulumi/cloudflare";
+
+const account = new cloudflare.Account('fabien.sh', {
+    name: 'fabien.sh'
+}, {protect: true});
+
+const zone = new cloudflare.Zone("fabien.sh", {
+    accountId: account.id,
+    plan: 'free',
+    zone: 'fabien.sh',
+}, {protect: true,});
+
+const script = new cloudflare.WorkerScript('curl-landing', {
+    accountId: account.id,
+    content: `/**
+ * Returns whether a request has a User-Agent
+ * hinting the requests comes from the curl CLI tool or library
+ *
+ * @param {Request} request
+ * @return {boolean}
+ */
+const isCurlUserAgent = (request) => {
+  return request.headers.get('user-agent')?.startsWith('curl/');
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    if (isCurlUserAgent(request)) {
+      return Response.json(
+        {
+          roles: ['cloud-engineer', 'platform-engineer', 'sre'],
+          status: 'freelance',
+          available: true,
+          topics: ['dev', 'infrastructure', 'platform']
+        },
+        {
+          status: 203,
+          statusText: 'Non-Authoritative Information'
+        });
+    }
+
+    return fetch(request);
+  },
+};
+`,
+    name: 'curl-landing',
+    module: true,
+}, {protect: true});
+
+new cloudflare.WorkerRoute('main', {
+    pattern: 'fabien.sh/*',
+    scriptName: script.name,
+    zoneId: zone.id,
+}, {protect: true});

--- a/infrastructure/cloudflare-workers/curl-landing/index.ts
+++ b/infrastructure/cloudflare-workers/curl-landing/index.ts
@@ -1,4 +1,6 @@
 import * as cloudflare from "@pulumi/cloudflare";
+import * as fs from 'fs';
+import * as path from 'path';
 
 const account = new cloudflare.Account('fabien.sh', {
     name: 'fabien.sh'
@@ -10,40 +12,12 @@ const zone = new cloudflare.Zone("fabien.sh", {
     zone: 'fabien.sh',
 }, {protect: true,});
 
+const scriptPath = path.join(__dirname, 'script', 'curl_landing.js');
+
 const script = new cloudflare.WorkerScript('curl-landing', {
-    accountId: account.id,
-    content: `/**
- * Returns whether a request has a User-Agent
- * hinting the requests comes from the curl CLI tool or library
- *
- * @param {Request} request
- * @return {boolean}
- */
-const isCurlUserAgent = (request) => {
-  return request.headers.get('user-agent')?.startsWith('curl/');
-}
-
-export default {
-  async fetch(request, env, ctx) {
-    if (isCurlUserAgent(request)) {
-      return Response.json(
-        {
-          roles: ['cloud-engineer', 'platform-engineer', 'sre'],
-          status: 'freelance',
-          available: true,
-          topics: ['dev', 'infrastructure', 'platform']
-        },
-        {
-          status: 203,
-          statusText: 'Non-Authoritative Information'
-        });
-    }
-
-    return fetch(request);
-  },
-};
-`,
     name: 'curl-landing',
+    accountId: account.id,
+    content: fs.readFileSync(scriptPath, 'utf8'),
     module: true,
 }, {protect: true});
 

--- a/infrastructure/cloudflare-workers/curl-landing/package-lock.json
+++ b/infrastructure/cloudflare-workers/curl-landing/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "name": "cloudflare-workers-curl-landing",
             "dependencies": {
+                "@pulumi/cloudflare": "^5.26.0",
                 "@pulumi/pulumi": "^3.113.0",
                 "typescript": "^5.0.0"
             },
@@ -615,6 +616,14 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
             "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
+        },
+        "node_modules/@pulumi/cloudflare": {
+            "version": "5.26.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/cloudflare/-/cloudflare-5.26.0.tgz",
+            "integrity": "sha512-M9TXQTn/3QllxG/oxWvVUzCkmSL520QH4WIK0Ua/4zy0y2e/mYf+klB7Sg0vLhLpUG2ZtcBdxInl4eUIgizExw==",
+            "dependencies": {
+                "@pulumi/pulumi": "^3.0.0"
+            }
         },
         "node_modules/@pulumi/pulumi": {
             "version": "3.113.1",

--- a/infrastructure/cloudflare-workers/curl-landing/package.json
+++ b/infrastructure/cloudflare-workers/curl-landing/package.json
@@ -5,6 +5,7 @@
         "@types/node": "^18"
     },
     "dependencies": {
+        "@pulumi/cloudflare": "^5.26.0",
         "@pulumi/pulumi": "^3.113.0",
         "typescript": "^5.0.0"
     }

--- a/infrastructure/cloudflare-workers/curl-landing/script/curl_landing.js
+++ b/infrastructure/cloudflare-workers/curl-landing/script/curl_landing.js
@@ -1,0 +1,30 @@
+/**
+ * Returns whether a request has a User-Agent
+ * hinting the requests comes from the curl CLI tool or library
+ *
+ * @param {Request} request
+ * @return {boolean}
+ */
+const isCurlUserAgent = (request) => {
+  return request.headers.get('user-agent')?.startsWith('curl/');
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    if (isCurlUserAgent(request)) {
+      return Response.json(
+        {
+          roles: ['cloud-engineer', 'platform-engineer', 'sre'],
+          status: 'freelance',
+          available: true,
+          topics: ['dev', 'infrastructure', 'platform']
+        },
+        {
+          status: 203,
+          statusText: 'Non-Authoritative Information'
+        });
+    }
+
+    return fetch(request);
+  },
+};


### PR DESCRIPTION
## Description

In order to be consistent with my LinkedIn banner, I decided to let a Cloudflare worker respond to `curl` request.

This allows a simple `curl -L fabien.sh` to return a nice JSON response.

<details><summary>The said LinkedIn banner...</summary><p>

![Screenshot_20240418_181310](https://github.com/fhuitelec/fabien.sh/assets/6122860/cb43b099-d517-4b4f-a8fb-f405984ee5ce)

</p></details>

This worker lets the request runs its course to the origin server or returns a JSON response if the user agent starts with `curl/`.

> [!note]
> There was no infra-as-code so this pull request imports & declares the associated resources.