### PR TITLE
Add HTTP headers to curl responses

### DIFF
--- a/infrastructure/cloudflare-workers/curl-landing/script/curl_landing.js
+++ b/infrastructure/cloudflare-workers/curl-landing/script/curl_landing.js
@@ -21,7 +21,14 @@ export default {
         },
         {
           status: 203,
-          statusText: 'Non-Authoritative Information'
+          statusText: 'Non-Authoritative Information',
+          headers: {
+            'X-Clacks-Overhead': 'GNU Terry Pratchett',
+            'X-Powered-By': 'Unicorns',
+            'X-Human': 'Hey there! Nice to see some people trying curl-ing me!',
+            'X-LinkedIn': 'linkedin.com/in/fhuitelec',
+            'X-Email': 'hey@fabien.sh',
+          }
         });
     }
 


### PR DESCRIPTION
## Description

Having a bit of fun by adding various non-meaningful HTTP headers to responses dedicated to `curl` User-Agents :slightly_smiling_face: 

```shell
curl -L fabien.sh -i

# > [...]
# > x-clacks-overhead: GNU Terry Pratchett
# > x-email: hey@fabien.sh
# > x-human: Hey there! Nice to see some people trying curl-ing me!
# > x-linkedin: linkedin.com/in/fhuitelec
# > x-powered-by: Unicorns
# > [...]

{"roles":["cloud-engineer","platform-engineer","sre"],"status":"freelance","available":true,"topics":["dev","infrastructure","platform"]}
```